### PR TITLE
Add main method for CLI subclass overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ quantumlib-chsh run --devices qulacs --shots 5000 --points 50 --backend oqtopus 
 ```
 
 Options:
+
 - `--points`: Number of phase points to scan (default: 20)
 
 ### Rabi Oscillation Experiment
@@ -62,6 +63,7 @@ quantumlib-rabi run --devices qulacs --shots 1000 --points 40 --backend oqtopus 
 ```
 
 Options:
+
 - `--points`: Number of amplitude points (default: 20)
 - `--max-amplitude`: Maximum drive amplitude in radians (default: 2π)
 
@@ -245,7 +247,7 @@ uv build
 
 ### Project Structure
 
-```
+```shell
 quantumlib/
 ├── src/quantumlib/          # Main library code
 │   ├── cli/                 # CLI framework

--- a/src/quantumlib/backend/oqtopus.py
+++ b/src/quantumlib/backend/oqtopus.py
@@ -36,7 +36,7 @@ class QuantumExperimentSimple:
     def __init__(
         self,
         experiment_name: str = None,
-        oqtopus_backend: OqtopusSamplingBackend | None = None,
+        oqtopus_backend: Any | None = None,
     ):
         """
         Initialize quantum experiment

--- a/src/quantumlib/core/base_experiment.py
+++ b/src/quantumlib/core/base_experiment.py
@@ -33,7 +33,7 @@ class BaseExperiment(ABC):
     def __init__(
         self,
         experiment_name: str = None,
-        oqtopus_backend: OqtopusSamplingBackend | None = None,
+        oqtopus_backend: Any | None = None,
     ):
         """
         Initialize base experiment

--- a/workspace/scripts/chsh.py
+++ b/workspace/scripts/chsh.py
@@ -183,6 +183,10 @@ class CHSHExperimentCLI(BaseExperimentCLI):
             points=points,  # CHSH specific option
         )
 
+    def main(self):
+        """CLI callback - Override in subclass"""
+        pass
+
 
 # CLI instance creation and execution
 def main():

--- a/workspace/scripts/rabi.py
+++ b/workspace/scripts/rabi.py
@@ -159,6 +159,10 @@ class RabiExperimentCLI(BaseExperimentCLI):
             max_amplitude=max_amplitude,  # Rabi specific option
         )
 
+    def main(self):
+        """CLI callback - Override in subclass"""
+        pass
+
 
 # CLI instance creation and execution
 def main():

--- a/workspace/scripts/ramsey.py
+++ b/workspace/scripts/ramsey.py
@@ -174,6 +174,10 @@ class RamseyExperimentCLI(BaseExperimentCLI):
             enable_fitting=enable_fitting,  # Fitting enable option
         )
 
+    def main(self):
+        """CLI callback - Override in subclass"""
+        pass
+
 
 # CLI instance creation and execution
 def main():

--- a/workspace/scripts/t1.py
+++ b/workspace/scripts/t1.py
@@ -156,6 +156,10 @@ class T1ExperimentCLI(BaseExperimentCLI):
             max_delay=max_delay,  # T1 specific option
         )
 
+    def main(self):
+        """CLI callback - Override in subclass"""
+        pass
+
 
 # CLI instance creation and execution
 def main():

--- a/workspace/scripts/t2_echo.py
+++ b/workspace/scripts/t2_echo.py
@@ -184,6 +184,10 @@ class T2EchoExperimentCLI(BaseExperimentCLI):
             enable_fitting=enable_fitting,  # Fitting enable option
         )
 
+    def main(self):
+        """CLI callback - Override in subclass"""
+        pass
+
 
 # CLI instance creation and execution
 def main():


### PR DESCRIPTION
Introduce a main method in CLI scripts to allow for easy subclass overrides, enhancing flexibility in command-line interface functionality. Adjustments made to type annotations for backend parameters to improve compatibility.