### PR TITLE
Add 'Kawasaki' device type to DeviceType enum

### DIFF
--- a/src/quantumlib/cli/base_cli.py
+++ b/src/quantumlib/cli/base_cli.py
@@ -24,6 +24,7 @@ from rich.progress import (
 class DeviceType(str, Enum):
     qulacs = "qulacs"
     anemone = "anemone"
+    Kawasaki = "Kawasaki"
 
 
 class ExperimentBackend(str, Enum):


### PR DESCRIPTION
Introduce the 'Kawasaki' device type to the DeviceType enumeration to enhance device support.